### PR TITLE
Fix files retrieval and services exportation

### DIFF
--- a/waves/wcore/views/files.py
+++ b/waves/wcore/views/files.py
@@ -17,7 +17,7 @@ class DownloadFileView(generic.DetailView):
     context_object_name = 'file'
     slug_field = 'slug'
     http_method_names = ['get', ]
-    _force_download = True
+    _force_download = False
     file_type = None
     object = None
 
@@ -30,8 +30,8 @@ class DownloadFileView(generic.DetailView):
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()
-        assert isinstance(self.object, ExportAbleMixin), 'Model object must be Export-able'
-        self.object.serialize()
+        if isinstance(self.object, ExportAbleMixin):
+            self.object.serialize()
         self.file_type = magic.from_file(self.file_path)
         export = 'export' in self.request.GET or self._force_download is True
         if 'text' not in self.file_type and not export:


### PR DESCRIPTION
This solution allows to use the get method of a DownloadFileView instance for both, exportable and not exportable objects. We can now see or download job results and export services for example.